### PR TITLE
Add git which is needed for npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER ViViDboarder <vividboarder@gmail.com>
 
 RUN apt-get update && \
-    apt-get install -y curl && \
+    apt-get install -y curl git && \
     curl --silent --location https://deb.nodesource.com/setup_6.x | bash && \
     apt-get install -y nodejs && \
     apt-get remove --purge -y curl && \


### PR DESCRIPTION
Npm install command needs git, otherwise this is the error you get:
```
Step 8/11 : RUN npm install && npm cache clean --force
 ---> Running in a288788bc87e
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:hooram/react-image-lightbox.git /root/.npm/_git-remotes/git-github-com-hooram-react-image-lightbox-git-51647394: undefined
npm ERR! git clone --template=/root/.npm/_git-remotes/_templates --mirror git@github.com:hooram/react-image-lightbox.git /root/.npm/_git-remotes/git-github-com-hooram-react-image-lightbox-git-51647394: undefined
npm WARN deprecated react-router-redux@5.0.0-alpha.9: This project is no longer maintained.
npm ERR! Linux 4.18.0-10-lowlatency
npm ERR! argv "/usr/bin/node" "/usr/bin/npm" "install"
npm ERR! node v6.15.0
npm ERR! npm  v3.10.10
npm ERR! code ENOGIT

npm ERR! not found: git
npm ERR! 
npm ERR! Failed using git.
npm ERR! This is most likely not a problem with npm itself.
npm ERR! Please check if you have git installed and in your PATH.

npm ERR! Please include the following file with any support request:
npm ERR!     /usr/src/app/npm-debug.log
```