### PR TITLE
Fix docker installation, now all works, fixes #8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 3000
 
 COPY . /usr/src/app
 
-CMD [ "npm", "start" ]
+CMD [ "./run.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - "backend:backend"
 
   backend:
-    image: hooram/ownphotos:dev
+    image: guysoft/ownphotos:dev
     container_name: ownphotos-backend
     volumes:
       # Your photos go here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     container_name: ownphotos-frontend
     image: guysoft/ownphotos-frontend:dev
     # For development uncomment this and comment the image name above
-    build: .
+    #build: .
     tty: true
     environment:
        # This is the path to the backend host public facing. if your website is ownphotos.org then this should be "ownphotos.org".

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,76 @@
 version: '2'
 
 services:
-  frontend:
-    image: ownphotos-frontend
+
+  proxy:
+    image: guysoft/ownphotos-proxy
+    tty: true
+    container_name: ownphotos-proxy
+    restart: always
+    links:
+      - "backend:backend"
+      - "frontend:frontend"
     ports:
-      - 3000:3000
+      - "3000:80"
+      
+  ownphotos-db:
+    image: postgres
+    container_name: ownphotos-db
+    restart: always
+    environment:
+    # This db password is internal, you can change it if you want, but also change it in ownphotos-backend container
+      - POSTGRES_PASSWORD=AaAa1234
+      - POSTGRES_DB=ownphotos
+    volumes:
+      - ownphotos-data:/var/lib/postgresql/data
+
+  frontend:
+    container_name: ownphotos-frontend
+    image: guysoft/ownphotos-frontend:dev
+    # For development uncomment this and comment the image name above
     build: .
+    tty: true
+    environment:
+       # This is the path to the backend host public facing. if your website is ownphotos.org then this should be "ownphotos.org".
+       # Default here is assuming you are running on localhost on port 3000 as given in ownphotos-proxy service
+       - BACKEND_HOST=localhost:3000
+    links:
+      - "backend:backend"
 
   backend:
-    image: ownphotos-backend
+    image: hooram/ownphotos:dev
+    container_name: ownphotos-backend
     volumes:
+      # Your photos go here
       - $HOME/Pictures/:/data
+      - media:/code/media
     environment:
-      DEBUG: 'true'
-    ports:
-      - 8000:8000
+      - SECRET_KEY=change_meme
+      # This is backend host from within the service, you dont need to change this
+      - BACKEND_HOST=backend
+      - ADMIN_EMAIL=admin@example.com
+      - ADMIN_USERNAME=admin
+      # Change your admin password!
+      - ADMIN_PASSWORD=admin
+      - DEBUG=true
+      - DB_BACKEND=postgresql
+      - DB_NAME=ownphotos
+      - DB_USER=postgres
+      # This db password is internal, you can change it if you want, but also change it in ownphotos-db container
+      - DB_PASS=AaAa1234
+      - DB_HOST=ownphotos-db
+      - DB_PORT=5432
+      - REDIS_HOST=ownphotos-redis
+      - REDIS_PORT=6379
+      - MAPBOX_API_KEY=CHANGE_MEAAAA
+    links:
+      - "ownphotos-db:ownphotos-db"
+      - "ownphotos-redis:ownphotos-redis"
+  
+  ownphotos-redis:
+    image: redis
+    container_name: ownphotos-redis
 
-  database:
-    image: postgres
-    environment:
-      POSTGRES_DB: ownphotos
-      POSTGRES_USER: ownphotos
-      POSTGRES_PASSWORD: ownphotos
-
-  memcached:
-    image: memcached
-
+volumes:
+  ownphotos-data:
+  media:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,21 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log;
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+  server {
+    listen 80;
+    location / {
+      proxy_pass http://frontend:3000/;
+    }
+    location /api {
+      proxy_pass http://backend/api;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-dropzone": "^4.2.12",
     "react-grid-gallery": "^0.4.11",
     "react-grid-layout": "^0.16.6",
-    "react-image-lightbox": "github:hooram/react-image-lightbox",
+    "react-image-lightbox": "https://github.com/hooram/react-image-lightbox",
     "react-keydown": "^1.9.4",
     "react-lazyload": "^2.2.7",
     "react-leaflet": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "redux-promise-middleware": "^5.1.1",
     "redux-thunk": "^2.3.0",
     "rumble-charts": "^2.0.0",
-    "semantic-ui": "^2.3.2",
     "semantic-ui-css": "^2.3.2",
     "semantic-ui-react": "^0.80.2"
   },

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sed -i "s@http://192.168.1.100@//${VIRTUAL_HOST}@g" src/api_client/apiClient.js
+sed -i "s@http://192.168.1.100:8000/@http://backend/@g" package.json
+DANGEROUSLY_DISABLE_HOST_CHECK=true HOST=0.0.0.0 npm start
+

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-sed -i "s@http://192.168.1.100@//${VIRTUAL_HOST}@g" src/api_client/apiClient.js
+sed -i "s@http://192.168.1.100@//${BACKEND_HOST}@g" src/api_client/apiClient.js
 sed -i "s@http://192.168.1.100:8000/@http://backend/@g" package.json
 DANGEROUSLY_DISABLE_HOST_CHECK=true HOST=0.0.0.0 npm start
 


### PR DESCRIPTION
Fixed docker-compose against latest .

Usage now is super simple and and can be run from localhost, or at a reverse proxy such as [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy). Without need to checkout the source and build the docker image locally.

Step by step usage assuming you are on localhost:

```
wget https://raw.githubusercontent.com/guysoft/ownphotos-frontend/dev/docker-compose.yml
sudo docker-compose up -d
```
Thats it, you have ownphotos ruining at ``http://localhost:3000``
(These commands already work now and you can test this)

For production deployments you 

Note: after this gets merged please update docker-compose.yml to a docker hub automated build for ``guysoft/ownphotos-proxy`` and ``guysoft/ownphotos-frontend:dev``.