### PR TITLE
Update docker hub to use hooram's image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - "backend:backend"
 
   backend:
-    image: guysoft/ownphotos:dev
+    image: hooram/ownphotos:dev
     container_name: ownphotos-backend
     volumes:
       # Your photos go here


### PR DESCRIPTION
Now that the build passes we can point to the official container.