### PR TITLE
regexp escape in fuzzy_match

### DIFF
--- a/src/layouts/FaceDashboardV3.js
+++ b/src/layouts/FaceDashboardV3.js
@@ -61,7 +61,7 @@ const SPEED_THRESHOLD = 500;
 
 function fuzzy_match(str, pattern) {
   if (pattern.split("").length > 0) {
-    pattern = pattern.split("").reduce(function(a, b) {
+    pattern = pattern.split("").map(a => _.escapeRegExp(a)).reduce(function(a, b) {
       return a + ".*" + b;
     });
     return new RegExp(pattern).test(str);


### PR DESCRIPTION
Without this, attempting to type in a character with special meaning in
regexp (such as a parenthesis) would cause an error. This change escapes
each character in the fuzzy search using lodash's escapeRegExp.